### PR TITLE
Don't use global router instance for SSR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "svelte-easyroute-ssr-template",
   "version": "1.0.0",
   "lockfileVersion": 1,
+  "preserveSymlinks": "1",
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv public",
-    "start:ssr": "node ./server.js"
+    "start:ssr": "npm run build; node ./server.js"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const fs = require('fs')
 const App = require('./public/ssr/bundle')
 
 // Create Svelte Easyroute renderer
-const renderer = require('svelte-easyroute/lib/ssr')()
+const renderer = require('./ssr/renderer');
 
 // Read template file
 const template = fs.readFileSync(__dirname + '/public/index.html', 'utf8')

--- a/src/App.ssr.svelte
+++ b/src/App.ssr.svelte
@@ -1,12 +1,13 @@
 <script context="module">
 	import { EasyrouteProvider, RouterOutlet, RouterLink, registerRouterSSR } from 'svelte-easyroute'
-	import router from "./router/router";
+	import initRouter from "./router/router";
 
-	registerRouterSSR(router)
+	registerRouterSSR(initRouter)
 </script>
 
 <script>
 	export let name;
+	export let router;
 </script>
 
 <EasyrouteProvider {router}>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { EasyrouteProvider, RouterOutlet, RouterLink } from 'svelte-easyroute'
-	import router from "./router/router";
+	import initRouter from "./router/router";
+
+	const router = initRouter();
 
 	export let name;
 </script>

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -19,9 +19,12 @@ const routes = [
     }
 ]
 
-const router = new Router({
-    mode: 'history',
-    routes
-})
+function initRouter(isSSR = false) {
+    const router = new Router({
+        mode: 'history',
+        routes
+    })
+    return router
+}
 
-export default router
+export default initRouter;

--- a/ssr/renderer.js
+++ b/ssr/renderer.js
@@ -1,0 +1,21 @@
+const deleteLastSlash = (url) => url.replace(/\/$/, '')
+const stripBase = (url, base) => (Boolean(base) ? url.replace(base, '') : url)
+
+module.exports = async function renderer(renderOptions) {
+    const initRouter = global.$$$easyrouteRouter
+    if (!initRouter)
+      throw new Error("[Easyroute SSR] Couldn't find Router factory")
+
+    const { component, props, url } = renderOptions
+
+    let [pathname, search] = url.split('?')
+    search = Boolean(search) ? '?' + search : ''
+    pathname = deleteLastSlash(pathname) + '/'
+
+    const router = initRouter(true);
+
+    await router.push(stripBase(`${pathname}${search}`, router.base))
+    return component.render({
+      ...props, router
+    })
+}


### PR DESCRIPTION
Hi @lyohaplotinka,

As a follow-up, I was able to get SSR running eventually - the component module signatures for SSR are different, and I was expecting a specific kind in order to hook everything up. 

However, I started to notice an unexpected side-effect of `global.$$$easyrouteRouter` being a router instance.

Since I had implemented some of my own `beforeLeave` hooks (as shown in the Sandbox.io demo I sent you by email), I saw how SSR requests were suddenly 'stateful': `beforeLeave` was triggered with the last visited url, even though the server should not actually be aware of this (as it could have been any request, not just mine).

In cases like this, it's always better to opt for a 'shared-none' approach, and solely operate within the boundary of a single request. As such, one should create a new router for every request - perhaps some optimizations can be made within `easyroute-core` which only recreates the 'history' for SSR (or better yet: doesn't keep anything stateful around).

Please have a look at the code. My solution piggy-backs on the current `global.$$$easyrouteRouter` but only to get the factory function that creates the router on each request. I'm sure there are better ways, but it's only to give you a general idea.